### PR TITLE
Remove --with-test from depext workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: opam pin add reddit_api.dev . --no-action
 
-      - run: opam depext reddit_api --yes --with-doc --with-test
+      - run: opam depext reddit_api --yes --with-doc
 
       - run: opam install . --deps-only --with-doc --with-test
 


### PR DESCRIPTION
There's an opam bug (https://github.com/ocaml/opam-repository/issues/17152) where test dependencies lead to erroneous detected cycles. It's fixed in opam 2.1 (in beta), but for now we don't care about running these tests.