### PR TITLE
Make Api.info return a list instead of a Listing.t

### DIFF
--- a/src/api.ml
+++ b/src/api.ml
@@ -823,14 +823,14 @@ struct
   let info ?subreddit query =
     let endpoint = optional_subreddit_endpoint ?subreddit "/api/info" in
     let params = Info_query.params_of_t query in
-    get
-      ~endpoint
-      ~params
-      (get_listing (fun json ->
-           let thing = Thing.Poly.of_json json in
-           match thing with
-           | (`Link _ | `Comment _ | `Subreddit _) as thing -> thing
-           | _ -> raise_s [%message "Unexpected kind in listing" (thing : Thing.Poly.t)]))
+    get ~endpoint ~params (fun response ->
+        let handle_json json =
+          let thing = Thing.Poly.of_json json in
+          match thing with
+          | (`Link _ | `Comment _ | `Subreddit _) as thing -> thing
+          | _ -> raise_s [%message "Unexpected kind in listing" (thing : Thing.Poly.t)]
+        in
+        get_listing handle_json response >>| Listing.children)
   ;;
 
   let lock' ~id = simple_toggle' "lock" id ignore_empty_object

--- a/src/api_intf.ml
+++ b/src/api_intf.ml
@@ -385,7 +385,7 @@ module type S = sig
        | `Link of Thing.Link.t
        | `Subreddit of Thing.Subreddit.t
        ]
-       Listing.t
+       list
        call
 
   (** Listings *)

--- a/test/test_comment_fields.ml
+++ b/test/test_comment_fields.ml
@@ -17,9 +17,7 @@ let%expect_test "comment_fields" =
       let comment_id = Thing.Comment.id first_comment in
       let%bind keys_from_info_page =
         match%bind
-          Api.Exn.info (Id [ `Comment comment_id ]) connection
-          >>| Listing.children
-          >>| List.hd_exn
+          Api.Exn.info (Id [ `Comment comment_id ]) connection >>| List.hd_exn
         with
         | `Comment comment -> return (Thing.Comment.field_map comment |> Map.key_set)
         | _ -> assert false

--- a/test/test_info.ml
+++ b/test/test_info.ml
@@ -6,7 +6,6 @@ let%expect_test "info" =
   with_cassette "info" ~f:(fun connection ->
       let%bind link =
         Api.Exn.info (Id [ `Link (Thing.Link.Id.of_string "hmjd8r") ]) connection
-        >>| Listing.children
         >>| List.hd_exn
       in
       let link =


### PR DESCRIPTION
It doesn't appear that the pagination is ever actually used.