### PR TITLE
Support uri.4.0.0

### DIFF
--- a/src/connection.ml
+++ b/src/connection.ml
@@ -378,7 +378,7 @@ module Remote = struct
         include Uri
         module Binable = String
 
-        let to_binable = Uri.to_string
+        let to_binable v = Uri.to_string v
         let of_binable = Uri.of_string
 
         let caller_identity =


### PR DESCRIPTION
`uri.4.0.0` broke CI by adding an optional parameter to `Uri.to_string`.

Since it's an optional parameter, I think this PR lets us support `uri.3` and `uri.4`.