### PR TITLE
Calculate reset time from header date

### DIFF
--- a/reddit_api_async/dune
+++ b/reddit_api_async/dune
@@ -2,5 +2,6 @@
  (name reddit_api_async)
  (public_name reddit_api_async)
  (libraries async core cohttp-async ezjsonm reddit_api_kernel sequencer_table)
+ (inline_tests)
  (preprocess
   (pps ppx_jane)))


### PR DESCRIPTION
Benefits:

* Don't need to thread through a [Time_source.t].
* Prevents random jitter of the next reset time.
* Can just compare reset times directly without needing to include a tolerance.