### PR TITLE
Convert JSON timestamps via floats

### DIFF
--- a/reddit_api_async/connection.ml
+++ b/reddit_api_async/connection.ml
@@ -110,8 +110,8 @@ module Local = struct
         let expiration =
           let additional_seconds =
             Json.find response_json [ "expires_in" ]
-            |> Json.get_int
-            |> Time_ns.Span.of_int_sec
+            |> Json.get_float
+            |> Time_ns.Span.of_sec
           in
           Time_ns.add (Time_source.now time_source) additional_seconds
         in

--- a/reddit_api_kernel/subreddit_traffic.ml
+++ b/reddit_api_kernel/subreddit_traffic.ml
@@ -7,9 +7,10 @@ let bail_on_json json ~module_name =
 ;;
 
 let get_time_and_rest json ~module_name =
-  match Json.get_list Json.get_int json with
-  | time :: rest ->
-    let time = Time_ns.Span.of_int_sec time |> Time_ns.of_span_since_epoch in
+  match Json.get_list ident json with
+  | time_json :: rest ->
+    let time = time time_json in
+    let rest = List.map rest ~f:int in
     time, rest
   | _ -> bail_on_json json ~module_name
 ;;


### PR DESCRIPTION
Don't convert JSON numbers to ints when the number represents a
timestamp. These are likely to overflow on 32 bit platforms.

Instead, convert to a float and then to a [Time_ns.t].