### PR TITLE
Add Connection.Access_token_error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
   OAuth2 userless (app-only) flow, so if you serialize the variant,
   a constructor name will be prepended to the sexp.
 - Restructured `Rate_limiter` and added expect tests.
+- Reorganize error types in `Connection` to distinguish errors in fetching an
+  access token.
+- Bump `Connection.Remote` protocol to version 2.
 
 # 0.1.1 (2020-12-30)
 

--- a/reddit_api_async/dune
+++ b/reddit_api_async/dune
@@ -1,7 +1,13 @@
 (library
  (name reddit_api_async)
  (public_name reddit_api_async)
- (libraries async core cohttp-async ezjsonm reddit_api_kernel sequencer_table)
+ (libraries
+  async
+  core
+  cohttp-async
+  ezjsonm
+  reddit_api_kernel
+  sequencer_table)
  (inline_tests)
  (preprocess
   (pps ppx_jane)))

--- a/reddit_api_async/stream.ml
+++ b/reddit_api_async/stream.ml
@@ -125,6 +125,7 @@ let iter
     ~init:()
     ~f:(fun () child -> f child)
     ~on_error:(fun () error ->
-      Log.Global.error_s [%message "Received error response" (error : Api.Api_error.t)];
+      Log.Global.error_s
+        [%message "Received error response" (error : Api.Api_error.t Connection.Error.t)];
       return ())
 ;;

--- a/reddit_api_async/stream.mli
+++ b/reddit_api_async/stream.mli
@@ -17,7 +17,7 @@ val fold
   -> get_before_parameter:('thing -> 'id)
   -> init:'state
   -> f:('state -> 'thing -> 'state Deferred.t)
-  -> on_error:('state -> Api.Api_error.t -> 'state Deferred.t)
+  -> on_error:('state -> Api.Api_error.t Connection.Error.t -> 'state Deferred.t)
   -> _ Deferred.t
 
 val fold_until_finished
@@ -28,5 +28,7 @@ val fold_until_finished
   -> init:'state
   -> f:('state -> 'thing -> ('state, 'result) Continue_or_stop.t Deferred.t)
   -> on_error:
-       ('state -> Api.Api_error.t -> ('state, 'result) Continue_or_stop.t Deferred.t)
+       ('state
+        -> Api.Api_error.t Connection.Error.t
+        -> ('state, 'result) Continue_or_stop.t Deferred.t)
   -> 'result Deferred.t

--- a/reddit_api_kernel/api.ml
+++ b/reddit_api_kernel/api.ml
@@ -578,7 +578,7 @@ module Api_error = struct
   type t =
     | Cohttp_raised of Exn.t
     | Json_parsing_error of
-        { exn : Exn.t
+        { error : Error.t
         ; response : Cohttp.Response.t
         ; body_string : string
         }
@@ -595,6 +595,13 @@ type 'a t =
   ; handle_response : Cohttp.Response.t * Cohttp.Body.t -> ('a, Api_error.t) Result.t
   ; sequencer : Sequencer.t option
   }
+
+let parse_json_response response body =
+  let body_string = Cohttp.Body.to_string body in
+  match Json.of_string body_string with
+  | Ok json -> Ok json
+  | Error error -> Error (Api_error.Json_parsing_error { error; response; body_string })
+;;
 
 let map t ~f =
   { t with handle_response = (fun v -> t.handle_response v |> Result.map ~f) }
@@ -653,42 +660,36 @@ let handle_json_response f (response, body) =
     | `Bad_request -> Ok `Bad_request
     | _ -> Error (Api_error.Http_error { response; body })
   in
-  let body_string = Cohttp.Body.to_string body in
-  match Json.of_string body_string with
-  | exception exn ->
-    Error
-      (Api_error.Json_parsing_error
-         { exn : Exn.t; response : Cohttp.Response.t; body_string : string })
-  | json ->
-    (match status with
-    | `Success ->
-      let errors =
-        match Json.find_opt json [ "json"; "errors" ] with
-        | None -> None
-        | Some list ->
-          (match Json.get_list ident list with
-           | [] -> None
-           | errors -> Some (List.map errors ~f:Json_response_error.of_json_http_success)
-            : Json_response_error.t list option)
+  let%bind json = parse_json_response response body in
+  match status with
+  | `Success ->
+    let errors =
+      match Json.find_opt json [ "json"; "errors" ] with
+      | None -> None
+      | Some list ->
+        (match Json.get_list ident list with
+         | [] -> None
+         | errors -> Some (List.map errors ~f:Json_response_error.of_json_http_success)
+          : Json_response_error.t list option)
+    in
+    (match errors with
+    | Some errors -> Error (Api_error.Json_response_errors errors)
+    | None -> Ok (f json))
+  | `Bad_request ->
+    (match Json.find_opt json [ "reason" ] with
+    | None -> Error (Http_error { response; body })
+    | Some reason ->
+      let error = Json.get_string reason in
+      let error_type =
+        Json.find_opt json [ "error_type" ] |> Option.map ~f:Json.get_string
       in
-      (match errors with
-      | Some errors -> Error (Api_error.Json_response_errors errors)
-      | None -> Ok (f json))
-    | `Bad_request ->
-      (match Json.find_opt json [ "reason" ] with
-      | None -> Error (Http_error { response; body })
-      | Some reason ->
-        let error = Json.get_string reason in
-        let error_type =
-          Json.find_opt json [ "error_type" ] |> Option.map ~f:Json.get_string
-        in
-        let details = Json.get_string (Json.find json [ "explanation" ]) in
-        let fields =
-          match Json.find_opt json [ "fields" ] with
-          | None -> []
-          | Some json -> Json.get_list Json.get_string json
-        in
-        Error (Json_response_errors [ { error_type; error; details; fields } ])))
+      let details = Json.get_string (Json.find json [ "explanation" ]) in
+      let fields =
+        match Json.find_opt json [ "fields" ] with
+        | None -> []
+        | Some json -> Json.get_list Json.get_string json
+      in
+      Error (Json_response_errors [ { error_type; error; details; fields } ]))
 ;;
 
 let assert_no_errors = handle_json_response (const ())
@@ -1934,7 +1935,7 @@ let edit_wiki_page ?previous ?reason ~content ~page:({ subreddit; page } : Wiki_
   post ~endpoint ~params (fun (response, body) ->
       match Cohttp.Response.status response with
       | `Conflict ->
-        let json = Json.of_string (Cohttp.Body.to_string body) in
+        let%bind json = parse_json_response response body in
         Ok (Error (Wiki_page.Edit_conflict.of_json json))
       | _ ->
         (match ignore_empty_object (response, body) with

--- a/reddit_api_kernel/api.mli
+++ b/reddit_api_kernel/api.mli
@@ -285,7 +285,7 @@ module Api_error : sig
   type t =
     | Cohttp_raised of Exn.t
     | Json_parsing_error of
-        { exn : Exn.t
+        { error : Error.t
         ; response : Cohttp.Response.t
         ; body_string : string
         }

--- a/reddit_api_kernel/json.ml
+++ b/reddit_api_kernel/json.ml
@@ -11,5 +11,5 @@ type t =
   ]
 [@@deriving sexp, bin_io]
 
-let of_string = from_string
+let of_string s = Or_error.try_with (fun () -> from_string s)
 let get_map t = Ezjsonm.get_dict t |> String.Map.of_alist_exn

--- a/test/test_error_handling.ml
+++ b/test/test_error_handling.ml
@@ -28,15 +28,16 @@ let%expect_test "Json error" =
         with
         | Ok () -> raise_s [%message "Expected API error"]
         | Error error ->
-          print_s [%message "" (error : Api.Api_error.t)];
+          print_s [%message "" (error : Api.Api_error.t Connection.Error.t)];
           return ()
       in
       [%expect
         {|
           (error
-           (Json_response_errors
-            (((error TOO_LONG) (error_type ()) (details "this is too long (max: 1000)")
-              (fields (ban_message)))))) |}];
+           (Endpoint_error
+            (Json_response_errors
+             (((error TOO_LONG) (error_type ())
+               (details "this is too long (max: 1000)") (fields (ban_message))))))) |}];
       return ())
 ;;
 
@@ -53,7 +54,7 @@ let%expect_test "HTTP error" =
                ~subreddit:(Subreddit_name.of_string "thirdrealm")
                ())
         with
-        | Error (Http_error _) ->
+        | Error (Endpoint_error (Http_error _)) ->
           print_s [%message "HTTP error"];
           return ()
         | Ok () | Error _ -> raise_s [%message "Expected HTTP error"]
@@ -72,14 +73,15 @@ let%expect_test "Bad request" =
         with
         | Ok _ -> raise_s [%message "Expected error"]
         | Error error ->
-          print_s [%message "" (error : Api.Api_error.t)];
+          print_s [%message "" (error : Api.Api_error.t Connection.Error.t)];
           return ()
       in
       [%expect
         {|
         (error
-         (Json_response_errors
-          (((error USER_DOESNT_EXIST) (error_type ())
-            (details "that user doesn't exist") (fields (id)))))) |}];
+         (Endpoint_error
+          (Json_response_errors
+           (((error USER_DOESNT_EXIST) (error_type ())
+             (details "that user doesn't exist") (fields (id))))))) |}];
       return ())
 ;;

--- a/test/test_oauth2_refresh_token.ml
+++ b/test/test_oauth2_refresh_token.ml
@@ -45,41 +45,42 @@ let%expect_test "oauth2_refresh_token_insufficient_scope" =
   [%expect
     {|
     (raised (
-      Http_error
-      (response (
-        (encoding (Fixed 38))
-        (headers (
-          (accept-ranges                 bytes)
-          (access-control-allow-origin   *)
-          (access-control-expose-headers X-Moose)
-          (cache-control  "max-age=0, must-revalidate")
-          (connection     keep-alive)
-          (content-length 38)
-          (content-type   "application/json; charset=UTF-8")
-          (date           "Sun, 25 Jul 2021 13:48:26 GMT")
-          (server         snooserv)
-          (set-cookie
-           "edgebucket=DOY2vtwecNrBUXjM3E; Domain=reddit.com; Max-Age=63071999; Path=/;  secure")
-          (set-cookie
-           "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None")
-          (set-cookie
-           "session_tracker=GiIdHGp9KRBNycfn5d.0.1627220906977.Z0FBQUFBQmdfV3VxLUtmQ04tRzlVQlQ4dVVGNFVRWGx0Rm1qX2tqMzlYMERCTWZCWTR6bnV1Wk1na3ladXJMNmo5a1BxQnU4VHZ0aGNwT0RWbEE1NFcwWDdZV3VLMWx5Qlp6a3hJSlhfdXYyOUVMUjlUNlY0N3B3d3JaazBRbmhjS0NncVM1dERtOXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jul-2021 15:48:26 GMT; secure; SameSite=None; Secure")
-          (set-cookie
-           "loid=0000000000dijrnrio.2.1627220906977.Z0FBQUFBQmdfV3VxY0tER3dTQXZyakFWdnpuSjJFcW1jNmhLeG9CWWNUcHpXMXVTMlpNNXA5YWtYTjJoLWIwNWRDcU5tNFluTkF1cDZRZFZaRElPYzZNdjN6c2VFS01RbkFZMGpsa3AyLTZidElfRlJ1TkpKN2Nzdi1hUG8ycnIwUUxpUlB5eDRCZXg; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jul-2023 13:48:26 GMT; secure; SameSite=None; Secure")
-          (strict-transport-security
-           "max-age=15552000; includeSubDomains; preload")
-          (via "1.1 varnish")
-          (www-authenticate
-           "Bearer realm=\"reddit\", error=\"insufficient_scope\"")
-          (x-clacks-overhead      "GNU Terry Pratchett")
-          (x-content-type-options nosniff)
-          (x-frame-options        SAMEORIGIN)
-          (x-moose                majestic)
-          (x-ua-compatible        IE=edge)
-          (x-xss-protection       "1; mode=block")))
-        (version HTTP_1_1)
-        (status  Forbidden)
-        (flush   false)))
-      (body (String "{\"message\": \"Forbidden\", \"error\": 403}")))) |}];
+      Endpoint_error (
+        Http_error
+        (response (
+          (encoding (Fixed 38))
+          (headers (
+            (accept-ranges                 bytes)
+            (access-control-allow-origin   *)
+            (access-control-expose-headers X-Moose)
+            (cache-control  "max-age=0, must-revalidate")
+            (connection     keep-alive)
+            (content-length 38)
+            (content-type   "application/json; charset=UTF-8")
+            (date           "Sun, 25 Jul 2021 13:48:26 GMT")
+            (server         snooserv)
+            (set-cookie
+             "edgebucket=DOY2vtwecNrBUXjM3E; Domain=reddit.com; Max-Age=63071999; Path=/;  secure")
+            (set-cookie
+             "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None")
+            (set-cookie
+             "session_tracker=GiIdHGp9KRBNycfn5d.0.1627220906977.Z0FBQUFBQmdfV3VxLUtmQ04tRzlVQlQ4dVVGNFVRWGx0Rm1qX2tqMzlYMERCTWZCWTR6bnV1Wk1na3ladXJMNmo5a1BxQnU4VHZ0aGNwT0RWbEE1NFcwWDdZV3VLMWx5Qlp6a3hJSlhfdXYyOUVMUjlUNlY0N3B3d3JaazBRbmhjS0NncVM1dERtOXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jul-2021 15:48:26 GMT; secure; SameSite=None; Secure")
+            (set-cookie
+             "loid=0000000000dijrnrio.2.1627220906977.Z0FBQUFBQmdfV3VxY0tER3dTQXZyakFWdnpuSjJFcW1jNmhLeG9CWWNUcHpXMXVTMlpNNXA5YWtYTjJoLWIwNWRDcU5tNFluTkF1cDZRZFZaRElPYzZNdjN6c2VFS01RbkFZMGpsa3AyLTZidElfRlJ1TkpKN2Nzdi1hUG8ycnIwUUxpUlB5eDRCZXg; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jul-2023 13:48:26 GMT; secure; SameSite=None; Secure")
+            (strict-transport-security
+             "max-age=15552000; includeSubDomains; preload")
+            (via "1.1 varnish")
+            (www-authenticate
+             "Bearer realm=\"reddit\", error=\"insufficient_scope\"")
+            (x-clacks-overhead      "GNU Terry Pratchett")
+            (x-content-type-options nosniff)
+            (x-frame-options        SAMEORIGIN)
+            (x-moose                majestic)
+            (x-ua-compatible        IE=edge)
+            (x-xss-protection       "1; mode=block")))
+          (version HTTP_1_1)
+          (status  Forbidden)
+          (flush   false)))
+        (body (String "{\"message\": \"Forbidden\", \"error\": 403}"))))) |}];
   return ()
 ;;


### PR DESCRIPTION
This module allows us to distinguish errors in fetching an access token from errors in calling the actual requested endpoint.

This change requires bumping the version of the [Connection.Remote] protocol.