### PR TITLE
Require ezjsonm >= 1.2.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
     (odoc :with-doc)
     (cohttp      (>= 5.0.0))
     (core_kernel (>= v0.14.0))
-    (ezjsonm     (>= 1.0))))
+    (ezjsonm     (>= 1.2.0))))
 
 (package
   (name reddit_api_async)
@@ -33,6 +33,6 @@
     (async_ssl         (>= v0.14.0))
     (cohttp-async      (>= 5.0.0))
     (core              (>= v0.14.0))
-    (ezjsonm           (>= 1.0))
+    (ezjsonm           (>= 1.2.0))
     (reddit_api_kernel (=  :version))
     (sequencer_table   (>= v0.14.0))))

--- a/reddit_api_async.opam
+++ b/reddit_api_async.opam
@@ -15,7 +15,7 @@ depends: [
   "async_ssl" {>= "v0.14.0"}
   "cohttp-async" {>= "5.0.0"}
   "core" {>= "v0.14.0"}
-  "ezjsonm" {>= "1.0"}
+  "ezjsonm" {>= "1.2.0"}
   "reddit_api_kernel" {= version}
   "sequencer_table" {>= "v0.14.0"}
 ]

--- a/reddit_api_kernel.opam
+++ b/reddit_api_kernel.opam
@@ -12,7 +12,7 @@ depends: [
   "odoc" {with-doc}
   "cohttp" {>= "5.0.0"}
   "core_kernel" {>= "v0.14.0"}
-  "ezjsonm" {>= "1.0"}
+  "ezjsonm" {>= "1.2.0"}
 ]
 dev-repo: "git+https://github.com/leviroth/ocaml-reddit-api.git"
 build: [


### PR DESCRIPTION
This is required because we use the `Jsonm.find_opt` introduced in 1.2.0. See [opam CI failure](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/50707a61d4e17d25ec6eb2f367bf2da6dfccdeb8).