### PR TITLE
Use Base-style containers

### DIFF
--- a/reddit_api_async/connection.ml
+++ b/reddit_api_async/connection.ml
@@ -616,9 +616,9 @@ module For_testing = struct
     val filter_string : t -> string -> string
     val insert_dummy_strings : t -> string -> string
   end = struct
-    type t = string String.Table.t
+    type t = string Hashtbl.M(String).t
 
-    let create () = String.Table.create ()
+    let create () = Hashtbl.create (module String)
 
     let add t ~secret ~placeholder =
       let placeholder = sprintf "<%s>" (String.uppercase placeholder) in

--- a/reddit_api_kernel/endpoint.ml
+++ b/reddit_api_kernel/endpoint.ml
@@ -1484,10 +1484,7 @@ let search'
       ; required' string "q" query
       ; include_optional Historical_span.params_of_t since
       ; include_optional Search_sort.params_of_t sort
-      ; optional
-          Search_type.to_string
-          "type"
-          (Option.map types ~f:Search_type.Set.to_list)
+      ; optional Search_type.to_string "type" (Option.map types ~f:Set.to_list)
       ; restrict_param
       ]
   in

--- a/reddit_api_kernel/endpoint.mli
+++ b/reddit_api_kernel/endpoint.mli
@@ -680,7 +680,7 @@ val search
      -> ?restrict_to_subreddit:Subreddit_name.t
      -> ?since:Historical_span.t
      -> ?sort:Search_sort.t
-     -> ?types:Search_type.Set.t
+     -> ?types:Set.M(Search_type).t
      -> unit
      -> query:string
      -> (Thing.Link.t Listing.t option

--- a/reddit_api_kernel/json.ml
+++ b/reddit_api_kernel/json.ml
@@ -12,4 +12,4 @@ type t =
 [@@deriving sexp, bin_io]
 
 let of_string s = Or_error.try_with (fun () -> from_string s)
-let get_map t = Ezjsonm.get_dict t |> String.Map.of_alist_exn
+let get_map t = Ezjsonm.get_dict t |> Map.of_alist_exn (module String)

--- a/reddit_api_kernel/json.mli
+++ b/reddit_api_kernel/json.mli
@@ -7,4 +7,4 @@ end
 type t = value [@@deriving sexp, bin_io]
 
 val of_string : string -> t Or_error.t
-val get_map : t -> t String.Map.t
+val get_map : t -> t Map.M(String).t

--- a/reddit_api_kernel/json_object.ml
+++ b/reddit_api_kernel/json_object.ml
@@ -2,7 +2,7 @@ open! Core_kernel
 include Json_object_intf
 
 module Utils = struct
-  type t = Json.t String.Map.t [@@deriving sexp, bin_io]
+  type t = Json.t Map.M(String).t [@@deriving sexp, bin_io]
 
   let field_map = ident
   let of_json = Json.get_map

--- a/reddit_api_kernel/json_object_intf.ml
+++ b/reddit_api_kernel/json_object_intf.ml
@@ -12,7 +12,7 @@ module type S_with_fields = sig
 
   val get_field : t -> string -> Json.t option
   val get_field_exn : t -> string -> Json.t
-  val field_map : t -> Json.t String.Map.t
+  val field_map : t -> Json.t Map.M(String).t
 end
 
 module type S_with_kind = sig
@@ -35,7 +35,7 @@ module type Json_object = sig
   module type S_with_kind = S_with_kind
 
   module Utils : sig
-    include S_with_fields with type t = Json.t String.Map.t
+    include S_with_fields with type t = Json.t Map.M(String).t
     include Sexpable.S with type t := t
 
     val optional_field : string -> (Json.t -> 'a) -> t -> 'a option

--- a/reddit_api_kernel/karma_list.ml
+++ b/reddit_api_kernel/karma_list.ml
@@ -5,7 +5,7 @@ module Entry = struct
 
   let of_json json =
     match json with
-    | `O alist -> String.Map.of_alist_exn alist
+    | `O alist -> Map.of_alist_exn (module String) alist
     | _ -> raise_s [%message "Invalid [Karma_list.Entry] JSON" (json : Json.t)]
   ;;
 

--- a/reddit_api_kernel/listing.ml
+++ b/reddit_api_kernel/listing.ml
@@ -34,7 +34,7 @@ let of_json convert_element json =
     | _ -> fail "Expected \"data\" to be an object"
   in
   let data =
-    match String.Map.of_alist data with
+    match Map.of_alist (module String) data with
     | `Ok map -> map
     | `Duplicate_key key -> fail (sprintf "Duplicate key: \"%s\"" key)
   in

--- a/reddit_api_kernel/stylesheet.ml
+++ b/reddit_api_kernel/stylesheet.ml
@@ -5,7 +5,7 @@ module Image = struct
 
   let of_json json =
     match json with
-    | `O alist -> String.Map.of_alist_exn alist
+    | `O alist -> Map.of_alist_exn (module String) alist
     | _ -> raise_s [%message "Unexpected stylesheet image json" (json : Json.t)]
   ;;
 

--- a/reddit_api_kernel/thing.ml
+++ b/reddit_api_kernel/thing.ml
@@ -11,7 +11,7 @@ struct
     let kind = Thing_kind.to_string Param.kind
   end)
 
-  type t = Json.t String.Map.t [@@deriving sexp, bin_io]
+  type t = Json.t Map.M(String).t [@@deriving sexp, bin_io]
 
   let module_name = Thing_kind.to_string_long Param.kind
 

--- a/test/test_comment_fields.ml
+++ b/test/test_comment_fields.ml
@@ -43,7 +43,7 @@ let%expect_test "comment_fields" =
       print_s [%sexp (Thing.Comment.permalink first_comment |> Uri.to_string : string)];
       [%expect
         {| https://reddit.com/r/ocaml/comments/hle3h4/ocaml_is_superbly_suited_to_defining_and/fwzc1p0/ |}];
-      print_s [%sexp (keys_from_info_page : String.Set.t)];
+      print_s [%sexp (keys_from_info_page : Set.M(String).t)];
       [%expect
         {|
         (all_awardings approved_at_utc approved_by archived associated_award author

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -61,7 +61,7 @@ let%expect_test "search__subreddits" =
           connection
           (Endpoint.search
              ()
-             ~types:(Endpoint.Parameters.Search_type.Set.singleton Subreddit)
+             ~types:(Set.singleton (module Endpoint.Parameters.Search_type) Subreddit)
              ~query:"ocaml")
       in
       print_links links;

--- a/test/test_subreddit_name.ml
+++ b/test/test_subreddit_name.ml
@@ -8,11 +8,11 @@ let%expect_test "Normalization" =
       ~f:Subreddit_name.of_string
       [ "askphilosophy"; "r/askphilosophy"; "/r/askphilosophy"; "/r/AskPhilosophy" ]
   in
-  let set = Subreddit_name.Set.of_list subreddit_names in
-  print_s [%message "" (set : Subreddit_name.Set.t)];
+  let set = Set.of_list (module Subreddit_name) subreddit_names in
+  print_s [%message "" (set : Set.M(Subreddit_name).t)];
   [%expect {| (set (askphilosophy)) |}];
-  let hash_set = Subreddit_name.Hash_set.of_list subreddit_names in
-  print_s [%message "" (hash_set : Subreddit_name.Hash_set.t)];
+  let hash_set = Hash_set.of_list (module Subreddit_name) subreddit_names in
+  print_s [%message "" (hash_set : Hash_set.M(Subreddit_name).t)];
   [%expect {| (hash_set (askphilosophy)) |}];
   return ()
 ;;

--- a/test/test_username.ml
+++ b/test/test_username.ml
@@ -6,11 +6,11 @@ let%expect_test "Normalization" =
   let usernames =
     List.map ~f:Username.of_string [ "spez"; "u/spez"; "/u/spez"; "/u/SPEZ" ]
   in
-  let set = Username.Set.of_list usernames in
-  print_s [%message "" (set : Username.Set.t)];
+  let set = Set.of_list (module Username) usernames in
+  print_s [%message "" (set : Set.M(Username).t)];
   [%expect {| (set (spez)) |}];
-  let hash_set = Username.Hash_set.of_list usernames in
-  print_s [%message "" (hash_set : Username.Hash_set.t)];
+  let hash_set = Hash_set.of_list (module Username) usernames in
+  print_s [%message "" (hash_set : Hash_set.M(Username).t)];
   [%expect {| (hash_set (spez)) |}];
   return ()
 ;;


### PR DESCRIPTION
For maps, sets, and hashtables, use `Container.value (module Module)` instead of `Module.Container.value`, and `Container.M(Module).t` instead of `Module.Container.t`.