### PR TITLE
Stream takes Hashtbl.Key_plain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - Log when `Retry_manager` retries.
 - Rename `Json_object.Util.time` => `time_sec_since_epoch`.
 - Require Jane Street libraries >= v0.15.0.
+- Make `Stream` functions require a `Hashtbl.Key_plain` module instead of the
+  larger `Hashable.S`.
 
 ## Removed
 

--- a/reddit_api_async/bounded_set.ml
+++ b/reddit_api_async/bounded_set.ml
@@ -1,12 +1,19 @@
 open! Core
 
-module Make (Hashable : Hashable.S) = struct
+module Make (Hashable : Hashtbl.Key_plain) = struct
   type t =
     { capacity : int
-    ; hash_queue : unit Hashable.Hash_queue.t
+    ; hash_queue : (Hashable.t, unit) Hash_queue.t
     }
 
-  let create ~capacity = { capacity; hash_queue = Hashable.Hash_queue.create () }
+  let create ~capacity =
+    { capacity
+    ; hash_queue =
+        Hash_queue.create
+          (let open Hashable in
+          { hash; compare; sexp_of_t })
+    }
+  ;;
 
   let mem { hash_queue; _ } value =
     match Hash_queue.lookup_and_move_to_back hash_queue value with

--- a/reddit_api_async/bounded_set.mli
+++ b/reddit_api_async/bounded_set.mli
@@ -1,6 +1,6 @@
 open! Core
 
-module Make (Hashable : Hashable.S) : sig
+module Make (Hashable : Hashtbl.Key_plain) : sig
   type t
 
   val create : capacity:int -> t

--- a/reddit_api_async/stream.ml
+++ b/reddit_api_async/stream.ml
@@ -33,7 +33,7 @@ let fold_helper l ~init ~f =
 
 let fold_until_finished
     (type id)
-    (module Id : Hashable.S with type t = id)
+    (module Id : Hashtbl.Key_plain with type t = id)
     connection
     ~get_listing
     ~get_before_parameter
@@ -87,7 +87,7 @@ let fold_until_finished
 
 let fold
     (type id)
-    (module Id : Hashable.S with type t = id)
+    (module Id : Hashtbl.Key_plain with type t = id)
     connection
     ~get_listing
     ~get_before_parameter
@@ -111,7 +111,7 @@ let fold
 
 let iter
     (type id)
-    (module Id : Hashable.S with type t = id)
+    (module Id : Hashtbl.Key_plain with type t = id)
     connection
     ~get_listing
     ~get_before_parameter

--- a/reddit_api_async/stream.mli
+++ b/reddit_api_async/stream.mli
@@ -3,7 +3,7 @@ open! Async
 open Reddit_api_kernel
 
 val iter
-  :  (module Hashable.S with type t = 'id)
+  :  (module Hashtbl.Key_plain with type t = 'id)
   -> Connection.t
   -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
   -> get_before_parameter:('thing -> 'id)
@@ -12,7 +12,7 @@ val iter
   -> _ Deferred.t
 
 val fold
-  :  (module Hashable.S with type t = 'id)
+  :  (module Hashtbl.Key_plain with type t = 'id)
   -> Connection.t
   -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
   -> get_before_parameter:('thing -> 'id)
@@ -22,7 +22,7 @@ val fold
   -> _ Deferred.t
 
 val fold_until_finished
-  :  (module Hashable.S with type t = 'id)
+  :  (module Hashtbl.Key_plain with type t = 'id)
   -> Connection.t
   -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
   -> get_before_parameter:('thing -> 'id)


### PR DESCRIPTION
This is a smaller interface than the previous Hashable.S, and is more consistent with our approach of using Base-style containers.