### PR TITLE
Stream uses pipe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,9 @@
 - Require Jane Street libraries >= v0.15.0.
 - Make `Stream` functions require a `Hashtbl.Key_plain` module instead of the
   larger `Hashable.S`.
-- Fixed a bug with `Mod_action.moderator`.
+- Fix a bug with `Mod_action.moderator`.
+- Change `Stream` to provide one function, `stream`, that returns a pipe,
+  instead of several functions with different interfaces.
 
 ## Removed
 

--- a/reddit_api_async/bounded_set.ml
+++ b/reddit_api_async/bounded_set.ml
@@ -8,10 +8,7 @@ module Make (Hashable : Hashtbl.Key_plain) = struct
 
   let create ~capacity =
     { capacity
-    ; hash_queue =
-        Hash_queue.create
-          (let open Hashable in
-          { hash; compare; sexp_of_t })
+    ; hash_queue = Hash_queue.create (Hashtbl.Hashable.of_key (module Hashable))
     }
   ;;
 

--- a/reddit_api_async/stream.mli
+++ b/reddit_api_async/stream.mli
@@ -2,34 +2,9 @@ open! Core
 open! Async
 open Reddit_api_kernel
 
-val iter
+val stream
   :  (module Hashtbl.Key_plain with type t = 'id)
   -> Connection.t
   -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
   -> get_before_parameter:('thing -> 'id)
-  -> log:Log.t option
-  -> f:('thing -> unit Deferred.t)
-  -> _ Deferred.t
-
-val fold
-  :  (module Hashtbl.Key_plain with type t = 'id)
-  -> Connection.t
-  -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
-  -> get_before_parameter:('thing -> 'id)
-  -> init:'state
-  -> f:('state -> 'thing -> 'state Deferred.t)
-  -> on_error:('state -> Endpoint.Error.t Connection.Error.t -> 'state Deferred.t)
-  -> _ Deferred.t
-
-val fold_until_finished
-  :  (module Hashtbl.Key_plain with type t = 'id)
-  -> Connection.t
-  -> get_listing:(before:'id option -> limit:int -> 'thing list Endpoint.t)
-  -> get_before_parameter:('thing -> 'id)
-  -> init:'state
-  -> f:('state -> 'thing -> ('state, 'result) Continue_or_stop.t Deferred.t)
-  -> on_error:
-       ('state
-        -> Endpoint.Error.t Connection.Error.t
-        -> ('state, 'result) Continue_or_stop.t Deferred.t)
-  -> 'result Deferred.t
+  -> ('thing, Endpoint.Error.t Connection.Error.t) Result.t Pipe.Reader.t


### PR DESCRIPTION
Change `Stream` to provide one function, `stream`, that returns a pipe, instead of several functions with different interfaces.